### PR TITLE
New index entry types

### DIFF
--- a/doc2dash/parsers/types.py
+++ b/doc2dash/parsers/types.py
@@ -1,6 +1,6 @@
 CLASS = 'cl'
-PACKAGE = 'cat'
+PACKAGE = 'Module'
 METHOD = 'clm'
 FUNCTION = 'func'
-ATTRIBUTE = 'instp'
+ATTRIBUTE = 'Attribute'
 CONSTANT = 'clconst'


### PR DESCRIPTION
Dash now supports a lot of new entry types. For example, previously,
modules were indexed as "Categories", Dash now supports a "Module"
entry type. The full list of entry types can be found at
http://kapeli.com/docsets/.
