### PR TITLE
Dash supports more plist keys: DashDocSetFallbackURL & isJavaScriptEnabled

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -8,3 +8,4 @@ contributors:
 - `Dirkjan Ochtman <https://github.com/djc>`_
 - `Henrique Bastos <https://github.com/henriquebastos>`_
 - `Łukasz Langa <https://github.com/ambv>`_
+- `Paul Kehrer <https://github.com/reaperhulk>`_

--- a/doc2dash/__main__.py
+++ b/doc2dash/__main__.py
@@ -79,9 +79,18 @@ class ClickEchoHandler(logging.Handler):
 @click.option(
     "--verbose", "-v", is_flag=True, help="Be verbose."
 )
+@click.option(
+    "--enable-js", "-j", is_flag=True,
+    help="Enable bundled and external Javascript."
+)
+@click.option(
+    "--online-redirect-url", "-u", default=None,
+    help="The base URL of the online documentation."
+)
 @click.version_option(version=__version__)
 def main(source, force, name, quiet, verbose, destination, add_to_dash,
-         add_to_global, icon, index_page):
+         add_to_global, icon, index_page, enable_js,
+         online_redirect_url):
     """
     Convert docs from SOURCE to Dash.app's docset format.
     """
@@ -113,7 +122,8 @@ def main(source, force, name, quiet, verbose, destination, add_to_dash,
             .format(click.format_filename(source))
         )
         raise SystemExit(errno.EINVAL)
-    docset = prepare_docset(source, dest, name, index_page)
+    docset = prepare_docset(source, dest, name, index_page, enable_js,
+                            online_redirect_url)
     doc_parser = dt(doc_path=docset.docs)
     log.info((u'Converting ' + click.style('{parser_name}', bold=True) +
               u' docs from "{src}" to "{dst}".')
@@ -212,7 +222,8 @@ class DocSet(object):
     pass
 
 
-def prepare_docset(source, dest, name, index_page):
+def prepare_docset(source, dest, name, index_page, enable_js,
+                   online_redirect_url):
     """
     Create boilerplate files & directories and copy vanilla docs inside.
 
@@ -237,9 +248,12 @@ def prepare_docset(source, dest, name, index_page):
         'DocSetPlatformFamily': name.lower(),
         'DashDocSetFamily': 'python',
         'isDashDocset': True,
+        'isJavaScriptEnabled': enable_js,
     }
     if index_page is not None:
         plist_cfg['dashIndexFilePath'] = index_page
+    if online_redirect_url is not None:
+        plist_cfg['DashDocSetFallbackURL'] = online_redirect_url
 
     plistlib.writePlist(
         plist_cfg,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,7 +11,7 @@ Changelog
   The move from ``unicode_literals`` to explicit prefixes broke some things that are fixed now.
   (`#29 <https://github.com/hynek/doc2dash/issues/29>`_, `#30 <https://github.com/hynek/doc2dash/issues/30>`_)
 - Fix detection of `pydoctor 0.5 <http://bazaar.launchpad.net/~mwhudson/pydoctor/dev/revision/605>`_. (`#31 <https://github.com/hynek/doc2dash/issues/31>`_)
-- Add support for ``--enable-js`` and ``-online-redirect-url`` options. See :doc:`/usage` for more information.
+- Add support for ``--enable-js`` and ``--online-redirect-url`` options. See :doc:`/usage` for more information.
 
 
 2.0.0 (2014-08-14)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,6 +11,7 @@ Changelog
   The move from ``unicode_literals`` to explicit prefixes broke some things that are fixed now.
   (`#29 <https://github.com/hynek/doc2dash/issues/29>`_, `#30 <https://github.com/hynek/doc2dash/issues/30>`_)
 - Fix detection of `pydoctor 0.5 <http://bazaar.launchpad.net/~mwhudson/pydoctor/dev/revision/605>`_. (`#31 <https://github.com/hynek/doc2dash/issues/31>`_)
+- Add support for ``--enable-js`` and ``-online-redirect-url`` options. See :doc:`/usage` for more information.
 
 
 2.0.0 (2014-08-14)

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -52,6 +52,16 @@ Valid ``OPTIONS`` are the following:
    Create docset in doc2dash's default global directory [``~/Library/Application Support/ doc2dash/DocSets``] and add it to Dash.app
    Works only on OS X and when Dash.app is installed.
 
+.. option:: -j, --enable-js
+
+    Enable bundled and external javascript.
+
+.. option:: -u, --online-redirect-url
+
+    As of Dash 3.0 users can open the online version of pages from within docsets.
+    To enable this, you must set this value to the base URL of your online documentation.
+    e.g. ``https://doc2dash.readthedocs.org/``
+
 .. option:: -q, --quiet
 
    Limit output to errors and warnings.


### PR DESCRIPTION
This PR adds support for both based on the information provided in https://kapeli.com/docsets#improveDocset

I'm not sure if I've tested this effectively so let me know what you'd like improved hynek :)

Also, the description for `isJavaScriptEnabled` (https://kapeli.com/docsets#enableJavascript) is really not very good. It seems like you need it to be `True` to use bundled JS assets, not actual remote ones?