### PR TITLE
Fix html anchor parsing wrong in some docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -4,6 +4,7 @@ Credits
 ``doc2dash`` is written and maintained by Hynek Schlawack and various
 contributors:
 
+- `Ashera Scout <https://github.com/asherascout>`_
 - `Bogdan Popescu <https://kapeli.com/dash>`_
 - `Dirkjan Ochtman <https://github.com/djc>`_
 - `Henrique Bastos <https://github.com/henriquebastos>`_

--- a/doc2dash/parsers/intersphinx.py
+++ b/doc2dash/parsers/intersphinx.py
@@ -100,6 +100,15 @@ def _inv_to_entries(inv):
         try:
             t = INV_TO_TYPE[type_key.split(":")[-1]]
             for el, data in iteritems(val):
-                yield ParserEntry(name=el, type=t, path=data[2])
+                """
+                Discard the anchors between head and tail to make it
+                compatible with situations that extra meta information encoded
+                """
+                path_tuple = data[2].split("#")
+                if len(path_tuple) > 1:
+                    path_str = "#".join((path_tuple[0], path_tuple[-1]))
+                else:
+                    path_str = data[2]
+                yield ParserEntry(name=el, type=t, path=path_str)
         except KeyError:
             pass

--- a/tests/parsers/intersphinx/test_intersphinx.py
+++ b/tests/parsers/intersphinx/test_intersphinx.py
@@ -39,11 +39,25 @@ class TestInterSphinxParser(object):
         result = list(
             _inv_to_entries({"py:method": {
                 u"some_method": (None, None, u"some_module.py", u"-"),
+            },
+            "std:option": {
+                u"--destination": (
+                    u"doc2dash",
+                    u"2.0",
+                    u"index.html#document-usage#cmdoption--destination",
+                    u"-"
+                )
             }})
         )
         assert [ParserEntry(
             name=u'some_method', type=u'Method', path=u'some_module.py'
-        )] == result
+            ),
+            ParserEntry(
+                name=u'--destination',
+                type=u'Option',
+                path=u'index.html#cmdoption--destination'
+            )
+        ] == result
 
 
 class TestFindAndPatchEntry(object):


### PR DESCRIPTION
Some path parse from objects.inv like the one in alembic's would be
'index.html#document-api/ddl#alembic.ddl.mysql.MySQLChangeColumn'.
As you see, there is more than one '#' in this path, and it cannot
be recognised correctly.
That may be the inv file's error. This commit replace the path with
head and tail of the original one. It can fix this issue.