### PR TITLE
Fix flake8 error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -61,6 +61,7 @@ def read(*parts):
     with codecs.open(os.path.join(here, *parts), "rb", "utf-8") as f:
         return f.read()
 
+
 try:
     META_PATH
 except NameError:


### PR DESCRIPTION
This error seems to derive from a [recent change in pycodestyle](https://github.com/PyCQA/pycodestyle/issues/400) due to a BDFL clarification...