### PR TITLE
Dont skip first line of object.inv

### DIFF
--- a/src/doc2dash/parsers/intersphinx.py
+++ b/src/doc2dash/parsers/intersphinx.py
@@ -68,7 +68,6 @@ class InterSphinxParser(object):
         yield `ParserEntry`s.
         """
         with open(os.path.join(self.doc_path, "objects.inv"), "rb") as inv_f:
-            inv_f.readline()  # skip version line that is verified in detection
             for pe in self._inv_to_entries(
                     read_inventory_v2(inv_f, "", os.path.join)
             ):  # this is what Guido gave us `yield from` for :-|


### PR DESCRIPTION
It seems the sphinx inventory version is always on top, that's what we want, else we got this error:
```
$ ~/.local/bin/doc2dash --name openturns ~/projects/openturns/schueller/build/install/share/openturns/doc/html/
Converting intersphinx docs from "html" to "./openturns.docset".
Parsing documentation...
Traceback (most recent call last):
  File ".local/bin/doc2dash", line 11, in <module>
    load_entry_point('doc2dash==2.2.0.dev0', 'console_scripts', 'doc2dash')()
  File "/usr/lib/python3.6/site-packages/click/core.py", line 722, in __call__
    return self.main(*args, **kwargs)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 697, in main
    rv = self.invoke(ctx)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 895, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/lib/python3.6/site-packages/click/core.py", line 535, in invoke
    return callback(*args, **kwargs)
  File ".local/lib/python3.6/site-packages/doc2dash-2.2.0.dev0-py3.6.egg/doc2dash/__main__.py", line 136, in main
  File ".local/lib/python3.6/site-packages/doc2dash-2.2.0.dev0-py3.6.egg/doc2dash/parsers/intersphinx.py", line 83, in parse
  File "/usr/lib/python3.6/site-packages/sphinx/util/inventory.py", line 108, in load
    raise ValueError('invalid inventory header: %s' % line)
ValueError: invalid inventory header: # Project: OpenTURNS
```

and the object.inv file is:
```
# Sphinx inventory version 2
# Project: OpenTURNS
# Version: .
# The remainder of this file is compressed using zlib.
x�̽_w�8��{>�o�sn��5�<w��$Z'˝���E��
```

I looked at my objects.inv through several sphinx releases from 1.2 to 1.6