### PR TITLE
Assure params are passed when called as module

### DIFF
--- a/src/doc2dash/__main__.py
+++ b/src/doc2dash/__main__.py
@@ -306,3 +306,7 @@ def add_icon(icon_data, dest):
     """
     with open(os.path.join(dest, 'icon.png'), "wb") as f:
         f.write(icon_data)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Previously executing `python -m doc2dash` would ignore
any command line parameters and command would
always exit as success without doing nothing.

This solves that issue and allows users to use the module
calling the same as the script execution, very important
feature because script may not always be in PATH after
module installation.

Fix: #88