### PR TITLE
Fix URL encoded filenames

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,7 +7,7 @@ Changelog
 ------------------
 
 - Fix URL decoding of filenames.
-  `#104 https://github.com/hynek/doc2dash/pull/104`
+  `#104 <https://github.com/hynek/doc2dash/pull/104>`_
 
 
 ----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,16 @@
 Changelog
 =========
 
+2.4.1 (2021-12-23)
+------------------
+
+- Fix URL decoding of filenames.
+  `#104 https://github.com/hynek/doc2dash/pull/104`
+
+
+----
+
+
 2.4.0 (2021-11-16)
 ------------------
 

--- a/src/doc2dash/parsers/utils.py
+++ b/src/doc2dash/parsers/utils.py
@@ -109,8 +109,8 @@ def patch_anchors(parser, show_progressbar):
 
     def patch_files(files):
         for fname, entries in files:
-            full_path = urllib.parse.unquote(
-                os.path.join(parser.doc_path, fname)
+            full_path = os.path.join(
+                parser.doc_path, urllib.parse.unquote(fname)
             )
             with codecs.open(full_path, mode="r", encoding="utf-8") as fp:
                 soup = BeautifulSoup(fp, "html.parser")

--- a/src/doc2dash/parsers/utils.py
+++ b/src/doc2dash/parsers/utils.py
@@ -3,6 +3,7 @@ import codecs
 import errno
 import logging
 import os
+import urllib
 
 from collections import defaultdict
 
@@ -108,7 +109,7 @@ def patch_anchors(parser, show_progressbar):
 
     def patch_files(files):
         for fname, entries in files:
-            full_path = os.path.join(parser.doc_path, fname)
+            full_path = urllib.parse.unquote(os.path.join(parser.doc_path, fname))
             with codecs.open(full_path, mode="r", encoding="utf-8") as fp:
                 soup = BeautifulSoup(fp, "html.parser")
                 for entry in entries:

--- a/src/doc2dash/parsers/utils.py
+++ b/src/doc2dash/parsers/utils.py
@@ -109,7 +109,9 @@ def patch_anchors(parser, show_progressbar):
 
     def patch_files(files):
         for fname, entries in files:
-            full_path = urllib.parse.unquote(os.path.join(parser.doc_path, fname))
+            full_path = urllib.parse.unquote(
+                os.path.join(parser.doc_path, fname)
+            )
             with codecs.open(full_path, mode="r", encoding="utf-8") as fp:
                 soup = BeautifulSoup(fp, "html.parser")
                 for entry in entries:

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -45,6 +45,14 @@ def entries():
     ]
 
 
+@pytest.fixture
+def entries_url_format():
+    return [
+        ParserEntry(name="foo", type="Method", path="foo%20bar.html#foo"),
+        ParserEntry(name="qux", type="Class", path="foo%20bar.html"),
+    ]
+
+
 class TestPatchTOCAnchors:
     @pytest.mark.parametrize("progressbar", [True, False])
     def test_with_empty_db(self, progressbar):
@@ -64,6 +72,21 @@ class TestPatchTOCAnchors:
         parser = FakeParser(doc_path=str(foo))
         toc = patch_anchors(parser, show_progressbar=False)
         for e in entries:
+            print(e)
+            toc.send(e)
+        toc.close()
+        assert [
+            TOCEntry(name="foo", type="Method", anchor="foo")
+        ] == parser._patched_entries
+
+    def test_single_entry_url_format(
+        self, monkeypatch, tmpdir, entries_url_format
+    ):
+        foo = tmpdir.mkdir("foo")
+        foo.join("foo bar.html").write("docs!")
+        parser = FakeParser(doc_path=str(foo))
+        toc = patch_anchors(parser, show_progressbar=False)
+        for e in entries_url_format:
             print(e)
             toc.send(e)
         toc.close()

--- a/tests/parsers/test_utils.py
+++ b/tests/parsers/test_utils.py
@@ -82,12 +82,14 @@ class TestPatchTOCAnchors:
     def test_single_entry_url_format(
         self, monkeypatch, tmpdir, entries_url_format
     ):
+    """
+    URL-encoded filenames are decoded before being added.
+    """
         foo = tmpdir.mkdir("foo")
         foo.join("foo bar.html").write("docs!")
         parser = FakeParser(doc_path=str(foo))
         toc = patch_anchors(parser, show_progressbar=False)
         for e in entries_url_format:
-            print(e)
             toc.send(e)
         toc.close()
         assert [


### PR DESCRIPTION
I was trying to use `doc2dash` with the documentation of [quimb](https://github.com/jcmgray/quimb) but the screen show the following error.

```python
Converting intersphinx docs from "html" to "./html.docset".
Parsing documentation...
Added 2,494 index entries.
Adding table of contents meta data...  [##################################################-------------------------------------------]   53%  00:00:18
Traceback (most recent call last):
  File "/Users/mofeing/Develop/quimb/.venv/bin/doc2dash", line 8, in <module>
    sys.exit(main())
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/doc2dash/__main__.py", line 227, in main
    toc.close()
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/doc2dash/parsers/utils.py", line 132, in patch_anchors
    patch_files(pbar)
  File "/Users/mofeing/Develop/quimb/.venv/lib/python3.8/site-packages/doc2dash/parsers/utils.py", line 112, in patch_files
    with codecs.open(full_path, mode="r", encoding="utf-8") as fp:
  File "/Users/mofeing/.pyenv/versions/3.8.2/lib/python3.8/codecs.py", line 905, in open
    file = builtins.open(filename, mode, buffering)
FileNotFoundError: [Errno 2] No such file or directory: './html.docset/Contents/Resources/Documents/calculating%20quantities.html'
```

Problem was that the repo generates some HTML files with spaces in their names and other files referencing to them encodes their names in URL form. Adding a URL decoding step solves the problem and does not interfere with other filenames.